### PR TITLE
Fix link for Sundials in the README file.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -32,7 +32,7 @@ Sundials:
 
 Sundials is a software package for solving systems of ODEs. It can be downloaded here:
 
-https://computation.llnl.gov/projects/sundials/sundials-software
+https://computing.llnl.gov/projects/sundials
 
 ** Important - make sure to download Sundials version 2.7, not the latest version!! This is the most common problem people run into when trying to get everything installed. **
 


### PR DESCRIPTION
The previous link (https://computation.llnl.gov/projects/sundials/sundials-software) to the Sundials website was not working, so I've proposed a replacement.